### PR TITLE
Removed version from composer.json for better Packagist compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "sort-packages": true
   },
   "prefer-stable": true,
-  "version": "1.0.0",
   "require-dev": {
     "phpunit/phpunit": "^11.4",
     "vlucas/phpdotenv": "^5.6"


### PR DESCRIPTION
Removed version field from composer.json to resolve versioning issues in Packagist