### PR TITLE
Remove "version" field for proper Packagist versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,5 @@
         "preferred-install": "dist",
         "sort-packages": true
     },
-    "prefer-stable": true,
-    "version": "1.0.0"
+    "prefer-stable": true
 }


### PR DESCRIPTION
Fix: Removed "version" field from composer.json for proper Packagist versioning