### PR TITLE
Add link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use MohsenNajafizadeh\TelegramNotifier\Telegram;
 
 $response = Telegram::sendMessage($message, $botToken, $chatId);
 ```
-For detailed documentation and examples, refer to the [Documentation](DOCUMENTATION.md).
+For detailed documentation and examples, refer to the [Documentation](DOCUMENTATION.md) /  [Documentation that created by PHPDocumentor](https://mohsen-najafizadeh.github.io/telegram-notifier/).
 
 ## License
 


### PR DESCRIPTION
This pull request updates the README file to include a link to the online documentation hosted on GitHub Pages. The documentation provides detailed information and examples for using the Telegram Notifier package.